### PR TITLE
[Dockerfile] Server static generated files in alpine nginx container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.github/
+.nuxt/
+.yarn/
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,29 @@
-FROM node:lts
+FROM node:lts AS builder
 
-# Clone and move into directory
-RUN git clone https://github.com/IntellectualSites/schematic-web.git /app
+# Set working directory
 WORKDIR /app
 
-# Install dependencies
-RUN yarn install
+# Install dependencies without lock file
+COPY package.json /app/package.json
+RUN yarn install --silent
 
-# Build application
-RUN yarn build
+# Get all remaining files
+COPY . /app
+
+# Generate static files
+RUN yarn run generate
+
+FROM nginx:stable-alpine
+
+# Copy dist files (generated) from builder layer into this (lightweight) nginx image
+COPY --from=builder /app/dist /usr/share/nginx/html
 
 # Expose the port
-EXPOSE 3000
+EXPOSE 80
 
-# Start the app
-CMD ["yarn", "start"]
+LABEL \
+  org.opencontainers.image.vendor="IntellectualSites" \
+  org.opencontainers.image.title="schematic-web" \
+  org.opencontainers.image.description="Frontend for arkitektonika" \
+  org.opencontainers.image.url="https://github.com/IntellectualSites" \
+  org.opencontainers.image.source="https://github.com/IntellectualSites/schematic-web"


### PR DESCRIPTION
## Overview
Outsourced the whole build-process in another image layer, which is not exported to keep the image at a minimal size.
As this site has no state or backend logic, we don't need to serve the webfiles using nuxt. Now static files are generated (index.html + chunk files) and served in an alpine nginx container / image.

Difference in Size: 1.38 GB -> 26.53 MB
![grafik](https://user-images.githubusercontent.com/27054324/194770487-243fd238-f43b-4c12-a51c-eff3aa22a3ef.png)

Sidenote: The exposed port has changed from 3000 -> 80 and no config.js exists anymore. Therefor configuration has to be made before building the final image. This will be changed in another PR (as the config.js will be moved to a static config.json and not transpiled into the chunk files)

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
